### PR TITLE
Use HTTPS for submodules instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "Sources/LVGLSwift/lvgl"]
 	path = Sources/CLVGL/lvgl
-	url = git@github.com:lvgl/lvgl.git
+	url = https://github.com/lvgl/lvgl.git
 [submodule "Sources/LVGLSwift/lv_drivers"]
 	path = Sources/CLVGL/lv_drivers
-	url = git@github.com:lvgl/lv_drivers.git
+	url = https://github.com/lvgl/lv_drivers.git


### PR DESCRIPTION
This has caused issues twice while I was trying to use this library. I didn't have SSH keys set up for git (and I think many people don't), so SwiftPM couldn't clone the package. Similarly, the GitHub actions workflow broke because it doesn't have SSH keys set up by default so it couldn't clone the package either. We could instead require users to set up SSH keys to use the package, but I don't really see a good reason for that.